### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete regular expression for hostnames

### DIFF
--- a/apps/web/cypress/support/commands.ts
+++ b/apps/web/cypress/support/commands.ts
@@ -160,7 +160,7 @@ export function registerCommands() {
   })
 
   Cypress.Commands.add('interceptQuoteRequest', (fixturePath) => {
-    return cy.intercept(/(?:interface|beta).gateway.uniswap.org\/v2\/quote/, (req) => {
+    return cy.intercept(/(?:interface|beta)\.gateway\.uniswap\.org\/v2\/quote/, (req) => {
       req.headers['origin'] = 'https://app.uniswap.org'
       req.reply({ fixture: fixturePath })
     })


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/interface/security/code-scanning/10](https://github.com/Dargon789/interface/security/code-scanning/10)

To fix the problem, we need to escape the `.` character in the regular expression to ensure it matches a literal dot rather than any character. This will make the regular expression more precise and prevent unintended matches.

- Locate the regular expression `(?:interface|beta).gateway.uniswap.org\/v2\/quote` on line 163 in the file `apps/web/cypress/support/commands.ts`.
- Modify the regular expression to escape the `.` character before `gateway` and `uniswap.org`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fix incomplete regular expression for hostnames.