### PR TITLE
Potential fix for code scanning alert no. 19: Incomplete regular expression for hostnames

### DIFF
--- a/apps/web/src/pages/Landing/Landing.e2e.test.ts
+++ b/apps/web/src/pages/Landing/Landing.e2e.test.ts
@@ -53,7 +53,7 @@ test.describe('Landing Page', () => {
       await page.unrouteAll({ behavior: 'ignoreErrors' })
     })
     test('renders UK compliance banner in UK', async ({ page }) => {
-      await page.route(/(?:interface|beta).gateway.uniswap.org\/v1\/amplitude-proxy/, async (route) => {
+      await page.route(/(?:interface|beta)\.gateway\.uniswap\.org\/v1\/amplitude-proxy/, async (route) => {
         const requestBody = JSON.stringify(await route.request().postDataJSON())
         const originalResponse = await route.fetch()
         const byteSize = new Blob([requestBody]).size


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/interface/security/code-scanning/19](https://github.com/Dargon789/interface/security/code-scanning/19)

To fix the problem, the periods (`.`) in the host part of the regular expression should be escaped with `\.` so that each matches a literal period rather than any character. In the given snippet, the regular expression `/(?:interface|beta).gateway.uniswap.org\/v1\/amplitude-proxy/` is used to intercept requests to domains like `interface.gateway.uniswap.org` or `beta.gateway.uniswap.org`. The intended match is specific subdomains leading to the gateway of `uniswap.org`, so escaping all the periods is the best way to ensure only these hosts are matched.

The fix is simple: replace every `.` in the host part (before `.org`) with `\.` so the regex becomes `/^(?:interface|beta)\.gateway\.uniswap\.org\/v1\/amplitude-proxy/` (using `^` makes the match stricter, but is optional). Make this change only on line 56 in the file `apps/web/src/pages/Landing/Landing.e2e.test.ts`.

No additional imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Escape the dots in the gateway.uniswap.org regex to ensure literal period matching and prevent unintended host matches