### PR TITLE
Potential fix for code scanning alert no. 17: Incomplete regular expression for hostnames

### DIFF
--- a/apps/web/src/playwright/fixtures/graphql.ts
+++ b/apps/web/src/playwright/fixtures/graphql.ts
@@ -58,7 +58,7 @@ export const test = base.extend<GraphqlFixture>({
       }
     }
 
-    await page.route(/(?:interface|beta).(gateway|api).uniswap.org\/v1\/graphql/, async (route) => {
+    await page.route(/(?:interface|beta)\.(gateway|api)\.uniswap\.org\/v1\/graphql/, async (route) => {
       const request = route.request()
       const postData = request.postData()
       if (!postData) {


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/interface/security/code-scanning/17](https://github.com/Dargon789/interface/security/code-scanning/17)

To fix the problem, the regular expression used in `page.route()` for matching the Uniswap GraphQL endpoints should escape the `.` characters in the host so that only the intended subdomains and domains are matched. In practice, every `.` in domain names should be replaced with `\.` in regular expressions. Specifically, change the pattern `/ (?:interface|beta).(gateway|api).uniswap.org\/v1\/graphql /` to use `\.` instead of `.`, resulting in `/ (?:interface|beta)\.(gateway|api)\.uniswap\.org\/v1\/graphql /`. This adjustment ensures that only hosts with literal dots are matched, preventing unintended behavior.

Only the line at the call to `page.route` in `apps/web/src/playwright/fixtures/graphql.ts` on line 61 needs to be updated, and no additional imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Escape dots in the regular expression for Uniswap GraphQL endpoints to restrict hostname matching to literal subdomains.