### PR TITLE
Delete .github/workflows/notify vercel.yml

### DIFF
--- a/.github/workflows/notify vercel.yml
+++ b/.github/workflows/notify vercel.yml
@@ -1,4 +1,0 @@
-- name: 'notify vercel'
-  uses: 'vercel/repository-dispatch/actions/status@v1'
-  with:
-    name: Vercel - interface-web: notify vercel


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Delete the notify vercel GitHub Actions workflow file