### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete regular expression for hostnames

### DIFF
--- a/apps/web/cypress/support/commands.ts
+++ b/apps/web/cypress/support/commands.ts
@@ -144,7 +144,7 @@ export function registerCommands() {
 
   Cypress.Commands.add('interceptGraphqlOperation', (operationName, fixturePath) => {
     const graphqlInterceptions = Cypress.env('graphqlInterceptions')
-    cy.intercept(/(?:interface|beta).gateway.uniswap.org\/v1\/graphql/, (req) => {
+    cy.intercept(/(?:interface|beta)\.gateway\.uniswap\.org\/v1\/graphql/, (req) => {
       req.headers['origin'] = 'https://app.uniswap.org'
       const currentOperationName = req.body.operationName
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/interface/security/code-scanning/9](https://github.com/Dargon789/interface/security/code-scanning/9)

To fix the problem, we need to escape the `.` characters in the regular expression to ensure they match literal dots rather than any character. This will make the regular expression more precise and prevent unintended matches.

- Locate the regular expression on line 147 and line 163 in the file `apps/web/cypress/support/commands.ts`.
- Modify the regular expression to escape the `.` characters before `gateway` and `uniswap.org`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Correct the Cypress intercept regular expression to avoid overbroad matching of GraphQL endpoint hostnames.