### PR TITLE
build(deps): bump hono

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -244,7 +244,7 @@
     "fancy-canvas": "2.1.0",
     "framer-motion": "10.17.6",
     "graphql": "16.10.0",
-    "hono": "4.12.12",
+    "hono": "4.12.14",
     "html-entities": "2.6.0",
     "i18next": "23.10.0",
     "jotai": "1.3.7",


### PR DESCRIPTION
Bumps the npm_and_yarn group with 1 update in the /apps/web directory: [hono](https://github.com/honojs/hono).


Updates `hono` from 4.12.12 to 4.12.14
- [Release notes](https://github.com/honojs/hono/releases)
- [Commits](https://github.com/honojs/hono/compare/v4.12.12...v4.12.14)

---
updated-dependencies:
- dependency-name: hono dependency-version: 4.12.14 dependency-type: direct:production dependency-group: npm_and_yarn ...