### PR TITLE
Potential fix for code scanning alert no. 28: Incomplete URL substring sanitization

### DIFF
--- a/packages/uniswap/src/utils/datadog.web.ts
+++ b/packages/uniswap/src/utils/datadog.web.ts
@@ -66,26 +66,35 @@ function beforeSend(event: RumEvent, context: RumEventDomainContext): boolean {
     }
   }
 
-  if (event.type === 'resource' && event.resource.url.includes('gateway.uniswap.org')) {
-    const requestHeaders = (context as RumFetchResourceEventDomainContext).requestInit?.headers
-    if (requestHeaders) {
-      const headersRecord =
-        requestHeaders instanceof Headers
-          ? Object.fromEntries(requestHeaders.entries())
-          : Array.isArray(requestHeaders)
-            ? Object.fromEntries(requestHeaders)
-            : requestHeaders
-      const tradingApiHeaderValues = new Set<string>(Object.values(TradingApiHeaders))
-      const featureFlagHeaders: Record<string, string> = {}
-      for (const [key, value] of Object.entries(headersRecord)) {
-        if (tradingApiHeaderValues.has(key)) {
-          featureFlagHeaders[key] = String(value)
+  if (event.type === 'resource') {
+    let isGatewayUniswapRequest = false
+    try {
+      isGatewayUniswapRequest = new URL(event.resource.url).hostname === 'gateway.uniswap.org'
+    } catch {
+      isGatewayUniswapRequest = false
+    }
+
+    if (isGatewayUniswapRequest) {
+      const requestHeaders = (context as RumFetchResourceEventDomainContext).requestInit?.headers
+      if (requestHeaders) {
+        const headersRecord =
+          requestHeaders instanceof Headers
+            ? Object.fromEntries(requestHeaders.entries())
+            : Array.isArray(requestHeaders)
+              ? Object.fromEntries(requestHeaders)
+              : requestHeaders
+        const tradingApiHeaderValues = new Set<string>(Object.values(TradingApiHeaders))
+        const featureFlagHeaders: Record<string, string> = {}
+        for (const [key, value] of Object.entries(headersRecord)) {
+          if (tradingApiHeaderValues.has(key)) {
+            featureFlagHeaders[key] = String(value)
+          }
         }
-      }
-      if (Object.keys(featureFlagHeaders).length > 0) {
-        event.context = {
-          ...event.context,
-          tradingApiHeaders: featureFlagHeaders,
+        if (Object.keys(featureFlagHeaders).length > 0) {
+          event.context = {
+            ...event.context,
+            tradingApiHeaders: featureFlagHeaders,
+          }
         }
       }
     }

--- a/packages/uniswap/src/utils/datadog.web.ts
+++ b/packages/uniswap/src/utils/datadog.web.ts
@@ -66,12 +66,12 @@ function beforeSend(event: RumEvent, context: RumEventDomainContext): boolean {
     }
   }
 
-  if (event.type === 'resource') {
+  if (event.type === 'resource' && event.resource.url.includes('gateway.uniswap.org')) {
     let isGatewayUniswapRequest = false
     try {
       isGatewayUniswapRequest = new URL(event.resource.url).hostname === 'gateway.uniswap.org'
     } catch {
-      isGatewayUniswapRequest = false
+      // ignore invalid URLs
     }
 
     if (isGatewayUniswapRequest) {


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/interface/security/code-scanning/28](https://github.com/Dargon789/interface/security/code-scanning/28)

Use URL parsing and strict hostname comparison instead of substring matching.

Best fix in this file:
- In `packages/uniswap/src/utils/datadog.web.ts`, replace:
  - `event.type === 'resource' && event.resource.url.includes('gateway.uniswap.org')`
- With logic that:
  1. Verifies `event.type === 'resource'`
  2. Parses `event.resource.url` via `new URL(...)` in a `try/catch`
  3. Checks `parsed.hostname === 'gateway.uniswap.org'`
  4. Proceeds only when true

This preserves existing behavior (only enrich headers for gateway requests) while preventing false matches from path/query/other hostnames. No new imports are needed because `URL` is a global in browser environments.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
